### PR TITLE
Fix: Correct Interval Tab Icon and Standardize Icon Sizes

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -33,7 +33,7 @@ const TAB_CONFIG: ReadonlyArray<{
   {
     name: "interval",
     title: "Interval",
-    icon: { lib: "AntDesign", name: "clockcircleo" },
+    icon: { lib: "AntDesign", name: "clock-circle" },
     headerShown: true,
     headerTitle: "Interval Screen",
   },
@@ -87,11 +87,11 @@ export default function TabLayout() {
   const TabIcon = ({ icon, color }: { icon: IconSpec; color: string }) => {
     switch (icon.lib) {
       case "Ionicons":
-        return <Ionicons size={28} name={icon.name} color={color} />;
+        return <Ionicons size={24} name={icon.name} color={color} />;
       case "MaterialIcons":
-        return <MaterialIcons size={28} name={icon.name} color={color} />;
+        return <MaterialIcons size={24} name={icon.name} color={color} />;
       case "AntDesign":
-        return <AntDesign size={28} name={icon.name} color={color} />;
+        return <AntDesign size={24} name={icon.name} color={color} />;
       default:
         return null;
     }


### PR DESCRIPTION
### **User description**
**Problem:**
- The Intervals tab used an invalid AntDesign icon name `"clockcircleo"`, causing console warnings
- Tab icons were inconsistently sized at 28px

**Changes:**
- Updated Intervals tab icon from `"clockcircleo"` → `"clock-circle"` (valid AntDesign icon)
- Standardized all tab icon sizes from 28px → 24px for consistency

**Result:**
- No more icon warnings in console
- Intervals tab icon displays correctly
- Consistent icon sizing across all tabs

Fixes the icon warning issue and improves visual consistency.

Closes #25 


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed invalid AntDesign icon name `"clockcircleo"` to `"clock-circle"`

- Standardized tab icon sizes from 28px to 24px

- Eliminates console warnings and improves visual consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid icon<br/>clockcircleo"] -->|"Fix to valid name"| B["Valid icon<br/>clock-circle"]
  C["Inconsistent sizes<br/>28px"] -->|"Standardize"| D["Consistent sizes<br/>24px"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_layout.tsx</strong><dd><code>Fix icon name and standardize icon sizes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/(tabs)/_layout.tsx

<ul><li>Fixed Intervals tab icon from invalid <code>"clockcircleo"</code> to valid <br><code>"clock-circle"</code> AntDesign icon<br> <li> Reduced all tab icon sizes from 28px to 24px across Ionicons, <br>MaterialIcons, and AntDesign components<br> <li> Improves visual consistency and eliminates console warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/RecepBorekci/one-more-rep/pull/26/files#diff-ea7f70dea9b63c4fcf80ad308f46fc316bfd05e41531a2a44dd56e1ea215a637">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

