### PR TITLE
Fix Android Background Gradient Alignment

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -69,19 +69,17 @@ const styles = StyleSheet.create({
   },
   background: {
     position: "absolute",
-    zIndex: -1,
     height: "100%",
     width: "100%",
   },
   text: {
-    fontSize: 20,
+    fontSize: 18,
     textAlign: "center",
     fontFamily: "Inter-VariableFont",
-    fontWeight: "500",
+    fontWeight: "600",
   },
   button: {
     padding: 10,
-    marginBottom: 20,
     borderRadius: 5,
     cursor: "pointer",
     alignItems: "center",

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -20,36 +20,38 @@ export default function HomeScreen() {
     <View style={styles.container}>
       <LinearGradient
         colors={[
-          PALETTE.gray600,
+          PALETTE.gray200,
           PALETTE.white,
           PALETTE.white,
-          PALETTE.gray600,
+          PALETTE.gray200,
         ]}
-        locations={[0, 0.2, 0.5, 1]}
+        locations={[0, 0.25, 0.55, 1]}
         style={styles.background}
       />
-      <Logo />
-      <Pressable
-        style={({ pressed }) => [
-          styles.button,
-          pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
-        ]}
-        onPress={handleToggle}
-        accessibilityRole="button"
-        accessibilityState={{ selected: isPlaying }}
-        accessibilityLabel={isPlaying ? "Stop" : "Play"}
-      >
-        <Ionicons
-          name={iconName as IoniconName}
-          size={48}
-          color={PALETTE.orangePrimary}
-        />
-        <Text style={styles.buttonText}>{buttonLabel}</Text>
-      </Pressable>
-      <View style={styles.currentModeContainer}>
-        <Text style={styles.text}>Current Mode: {currentMode}</Text>
-        <Text style={styles.text}>Selected Language: {language}</Text>
-        <Text style={styles.text}>Interval: {interval}</Text>
+      <View style={styles.contentContainer}>
+        <Logo />
+        <Pressable
+          style={({ pressed }) => [
+            styles.button,
+            pressed && { opacity: 0.7, transform: [{ scale: 0.98 }] },
+          ]}
+          onPress={handleToggle}
+          accessibilityRole="button"
+          accessibilityState={{ selected: isPlaying }}
+          accessibilityLabel={isPlaying ? "Stop" : "Play"}
+        >
+          <Ionicons
+            name={iconName as IoniconName}
+            size={60}
+            color={PALETTE.orangePrimary}
+          />
+          <Text style={styles.buttonText}>{buttonLabel}</Text>
+        </Pressable>
+        <View style={styles.currentModeContainer}>
+          <Text style={styles.text}>Current Mode: {currentMode}</Text>
+          <Text style={styles.text}>Selected Language: {language}</Text>
+          <Text style={styles.text}>Interval: {interval}</Text>
+        </View>
       </View>
     </View>
   );
@@ -60,16 +62,14 @@ const styles = StyleSheet.create({
     flex: 1,
     height: "100%",
     alignItems: "center",
-    justifyContent: "space-evenly",
+  },
+  contentContainer: {
     paddingHorizontal: 30,
-    paddingBottom: 50,
     paddingTop: 120,
   },
   background: {
     position: "absolute",
-    left: 0,
-    right: 0,
-    top: 0,
+    zIndex: -1,
     height: "100%",
     width: "100%",
   },
@@ -81,6 +81,7 @@ const styles = StyleSheet.create({
   },
   button: {
     padding: 10,
+    marginBottom: 20,
     borderRadius: 5,
     cursor: "pointer",
     alignItems: "center",
@@ -88,10 +89,10 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     color: PALETTE.orangePrimary,
-    fontSize: 18,
+    fontSize: 24,
     textAlign: "center",
     fontFamily: "Inter-VariableFont",
-    fontWeight: "500",
+    fontWeight: "600",
   },
   currentModeContainer: {
     flexDirection: "column",

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -6,6 +6,7 @@ export const PALETTE = {
   yellowLight: "#FEF9E1",
   gray400: "#988C8C",
   gray600: "#929292",
+  gray200: "#B4B4B4",
   // Add more as needed: black, success, warning, etc.
 } as const;
 


### PR DESCRIPTION
### **User description**
## Summary
Fixes misaligned background gradient on the main page for Android devices by improving gradient positioning and layout structure.

## Changes Made

### Background Gradient Fix
- **Fixed positioning**: Replaced explicit `left`, `right`, `top` positioning with `zIndex: -1` to ensure proper layering on Android
- **Updated gradient colors**: Changed from `gray600` to lighter `gray200` (`#B4B4B4`) for better visual consistency
- **Adjusted gradient stops**: Updated locations from `[0, 0.2, 0.5, 1]` to `[0, 0.25, 0.55, 1]` for smoother transitions

### Layout Improvements
- **Added content container**: Wrapped content in a dedicated `contentContainer` View for better structure and spacing control
- **Removed conflicting styles**: Removed `justifyContent: "space-evenly"` from main container to prevent layout conflicts

### UI Enhancements
- Increased play/stop icon size from 48 to 60
- Increased button text size from 18 to 24
- Updated button text font weight from 500 to 600
- Added margin bottom to button for better spacing

## Testing
- ✅ Background gradient properly fills entire screen on Android
- ✅ No overlapping or cropped gradient areas
- ✅ Foreground components remain unchanged
- ✅ Web layout remains unaffected

## Related Issue
Fixes the misaligned background gradient issue on Android devices while maintaining visual consistency across platforms.

Closes #27


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Fixed Android background gradient misalignment using zIndex layering

- Refactored layout with contentContainer for improved structure

- Enhanced UI with larger icons (48→60) and button text (18→24)

- Updated gradient colors to gray200 and adjusted stop positions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HomeScreen Layout"] -->|"Add contentContainer"| B["Improved Structure"]
  C["Gradient Styling"] -->|"Change gray600 to gray200"| D["Better Visual Consistency"]
  E["Positioning"] -->|"Replace left/right/top with zIndex"| F["Proper Android Rendering"]
  G["UI Elements"] -->|"Increase sizes & weights"| H["Enhanced Readability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Colors.ts</strong><dd><code>Add gray200 color to palette</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

constants/Colors.ts

<ul><li>Added new <code>gray200</code> color (#B4B4B4) to the palette<br> <li> Provides lighter gray option for gradient and styling purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/RecepBorekci/one-more-rep/pull/28/files#diff-5ddc12da235f98e3b989d0ebac9e04f98f40b81d44d4f07e3e8275c4b2904630">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Refactor HomeScreen layout and enhance UI styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/(tabs)/index.tsx

<ul><li>Changed gradient colors from <code>gray600</code> to <code>gray200</code> for lighter appearance<br> <li> Updated gradient stop locations from <code>[0, 0.2, 0.5, 1]</code> to <code>[0, 0.25, </code><br><code>0.55, 1]</code><br> <li> Wrapped content in new <code>contentContainer</code> View for better layout <br>organization<br> <li> Increased icon size from 48 to 60 and button text size from 18 to 24<br> <li> Updated button text font weight from 500 to 600 and added 20px margin <br>bottom<br> <li> Removed <code>justifyContent: "space-evenly"</code> from main container<br> <li> Changed background gradient positioning from explicit left/right/top <br>to <code>zIndex: -1</code></ul>


</details>


  </td>
  <td><a href="https://github.com/RecepBorekci/one-more-rep/pull/28/files#diff-f1376aabc191da604c7467683d96ee39e243cbc17a4a4caaa41d43f1979a1ebd">+33/-32</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

