### PR TITLE
Fix Modes Screen Button Layout on Android

### DIFF
--- a/app/(tabs)/mode.tsx
+++ b/app/(tabs)/mode.tsx
@@ -7,12 +7,13 @@ import {
 } from "@/hooks/useVoiceLine";
 import { Picker } from "@react-native-picker/picker";
 import {
-  FlatList,
   Image,
   ImageSourcePropType,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from "react-native";
 
@@ -51,6 +52,11 @@ const modeImages: {
 export default function ModeScreen() {
   const { mode, language } = useVoiceLineState();
   const { setMode, setLanguage } = useVoiceLineUpdater();
+  const { width } = useWindowDimensions();
+
+  const GAP = 16;
+  const PADDING = 20;
+  const itemWidth = (width - PADDING * 2 - GAP) / 2;
 
   const handleModePress = (selectedMode: VoiceMode) => {
     setMode(selectedMode);
@@ -60,44 +66,38 @@ export default function ModeScreen() {
     setLanguage(selectedLanguage);
   };
 
-  const renderImage = ({
-    item,
-  }: {
-    item: {
-      id: number;
-      source: ImageSourcePropType;
-      name: string;
-      mode: VoiceMode;
-    };
-  }) => {
-    const isActive = mode === item.mode;
-
-    return (
-      <TouchableOpacity
-        style={[styles.imageContainer, isActive && styles.activeImageContainer]}
-        onPress={() => handleModePress(item.mode)}
-        accessibilityRole="button"
-        accessibilityLabel={`Select ${item.name} mode`}
-        accessibilityState={{ selected: isActive }}
-      >
-        <Image source={item.source} style={styles.image} />
-        <Text style={styles.modeText}>{item.name}</Text>
-      </TouchableOpacity>
-    );
-  };
-
   return (
-    <View style={styles.container}>
-      <View>
+    <ScrollView contentContainerStyle={styles.scrollContainer}>
+      <View style={{ width: width - PADDING * 2 }}>
         <Text style={styles.sectionHeading}>Choose Mode</Text>
-        <FlatList
-          data={modeImages}
-          renderItem={renderImage}
-          numColumns={2}
-          keyExtractor={(item) => item.id.toString()}
-          contentContainerStyle={styles.grid}
-          columnWrapperStyle={styles.row}
-        />
+        <View style={styles.gridContainer}>
+          {modeImages.map((item) => {
+            const isActive = mode === item.mode;
+            return (
+              <TouchableOpacity
+                key={item.id}
+                style={[
+                  styles.imageContainer,
+                  isActive && styles.activeImageContainer,
+                  { width: itemWidth },
+                ]}
+                onPress={() => handleModePress(item.mode)}
+                accessibilityRole="button"
+                accessibilityLabel={`Select ${item.name} mode`}
+                accessibilityState={{ selected: isActive }}
+              >
+                <Image
+                  source={item.source}
+                  style={[
+                    styles.image,
+                    { width: itemWidth - 20, height: itemWidth - 20 },
+                  ]}
+                />
+                <Text style={styles.modeText}>{item.name}</Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
         <Text style={styles.sectionHeading}>Choose Language</Text>
         <View style={styles.pickerContainer}>
           <Picker
@@ -113,26 +113,24 @@ export default function ModeScreen() {
           </Picker>
         </View>
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
+  scrollContainer: {
+    flexGrow: 1,
     alignItems: "center",
     justifyContent: "center",
+    backgroundColor: "#fff",
+    paddingVertical: 20,
   },
-  grid: {
-    alignItems: "center",
-    gap: 20,
-  },
-  row: {
-    justifyContent: "space-around",
-    gap: 50,
+  gridContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 16,
   },
   imageContainer: {
-    flex: 1,
     alignItems: "center",
     justifyContent: "center",
     borderWidth: 3,
@@ -145,19 +143,16 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.2,
     shadowRadius: 4,
   },
-  text: { fontSize: 20, fontWeight: "bold", textAlign: "center" },
   modeText: {
-    fontSize: 20,
+    fontSize: 18,
     fontWeight: "600",
     textAlign: "center",
     fontFamily: "Inter-VariableFont",
     color: "#000000",
+    marginTop: 5,
   },
   image: {
-    width: 160,
-    height: 160,
     borderRadius: 10,
-    marginVertical: 10,
     shadowColor: "#000",
     shadowOffset: {
       width: 0,
@@ -170,25 +165,22 @@ const styles = StyleSheet.create({
   pickerContainer: {
     borderColor: "#8F8787",
     borderWidth: 0.7,
-    padding: 5,
+    padding: 0,
     borderRadius: 12,
   },
   picker: {
     borderWidth: 0,
     borderRadius: 12,
-    fontSize: 20,
-    fontFamily: "Inter-VariableFont",
-    fontWeight: "400",
-    textAlign: "left",
-    paddingLeft: 5,
+    // fontSize doesn't work on Picker style on Android usually, but keeping it
     color: "#8F8787",
   },
   sectionHeading: {
-    fontSize: 24,
+    fontSize: 22,
     fontWeight: "600",
     textAlign: "left",
     fontFamily: "Inter-VariableFont",
     color: "#000000",
-    marginVertical: 20,
+    marginBottom: 10,
+    marginTop: 5,
   },
 });

--- a/app/(tabs)/mode.tsx
+++ b/app/(tabs)/mode.tsx
@@ -57,6 +57,7 @@ export default function ModeScreen() {
   const GAP = 16;
   const PADDING = 20;
   const itemWidth = (width - PADDING * 2 - GAP) / 2;
+  const IMAGE_PADDING_RATIO = 0.1;
 
   const handleModePress = (selectedMode: VoiceMode) => {
     setMode(selectedMode);
@@ -90,7 +91,10 @@ export default function ModeScreen() {
                   source={item.source}
                   style={[
                     styles.image,
-                    { width: itemWidth - 20, height: itemWidth - 20 },
+                    {
+                      width: itemWidth * (1 - IMAGE_PADDING_RATIO),
+                      height: itemWidth * (1 - IMAGE_PADDING_RATIO),
+                    },
                   ]}
                 />
                 <Text style={styles.modeText}>{item.name}</Text>


### PR DESCRIPTION
### **User description**
Closes #29

### Problem
On Android, the Mode selection buttons overlapped and collapsed vertically. The `FlatList` with `numColumns={2}` layout behaved inconsistently on Android.

### Solution
Replaced the `FlatList`-based grid with a `ScrollView` and explicit width calculations:

- Switched from `FlatList` with `numColumns={2}` to `ScrollView` with `flexWrap` container
- Added `useWindowDimensions()` to calculate item widths dynamically
- Set explicit widths for each mode button based on screen width, padding, and gap
- Used explicit image dimensions instead of flex-based sizing

### Changes
- Replaced `FlatList` with `ScrollView` + `flexWrap` grid
- Added dynamic width calculation: `itemWidth = (width - PADDING * 2 - GAP) / 2`
- Applied explicit widths to `imageContainer` and `image` styles
- Updated container styles for consistent spacing

### Testing
- ✅ Mode buttons render in a 2-column grid without overlap
- ✅ Proper spacing maintained between cards
- ✅ Layout remains stable on screen resize/rotation

This ensures consistent rendering across platforms by using explicit dimensions instead of relying on flex behavior that varies on Android.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced `FlatList` with `ScrollView` and flexWrap grid layout

- Added dynamic width calculations using `useWindowDimensions()` hook

- Set explicit image dimensions based on screen width for consistency

- Refined spacing, padding, and font sizes for better visual alignment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["FlatList with numColumns=2"] -->|"Replace with"| B["ScrollView + flexWrap"]
  C["Flex-based sizing"] -->|"Replace with"| D["Dynamic width calculation"]
  E["Fixed image dimensions"] -->|"Update to"| F["Screen-responsive dimensions"]
  B --> G["Consistent Android rendering"]
  D --> G
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mode.tsx</strong><dd><code>Refactor layout from FlatList to responsive ScrollView grid</code></dd></summary>
<hr>

app/(tabs)/mode.tsx

<ul><li>Replaced <code>FlatList</code> component with <code>ScrollView</code> and manual grid layout <br>using <code>flexWrap</code><br> <li> Introduced <code>useWindowDimensions()</code> hook to calculate responsive item <br>widths dynamically<br> <li> Changed from <code>renderImage</code> callback to inline <code>.map()</code> rendering with <br>explicit width styling<br> <li> Updated image dimensions from fixed <code>160x160</code> to calculated <code>itemWidth - </code><br><code>20</code> for responsive sizing<br> <li> Adjusted spacing: reduced <code>gap</code> from <code>50</code> to <code>16</code>, refined padding and <br>margins throughout<br> <li> Modified font sizes: section heading from <code>24</code> to <code>22</code>, mode text from <code>20</code> <br>to <code>18</code><br> <li> Simplified picker container styling and removed redundant style <br>properties</ul>


</details>


  </td>
  <td><a href="https://github.com/RecepBorekci/one-more-rep/pull/30/files#diff-18a9b3989c7bdb54c1aacb3714dc4005aa727215d3980bc0d24f9f70a333a9cb">+53/-61</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

